### PR TITLE
Can click on buildings and show data

### DIFF
--- a/energy_map/index.html
+++ b/energy_map/index.html
@@ -20,11 +20,26 @@
       width: 100%;
     }
   </style>
+  <style>
+    #features {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: 50%;
+      overflow: auto;
+      background: rgb(255, 255, 255);
+    }
+    #map canvas {
+      cursor: crosshair;
+    }
+  </style>
 </head>
 
 <body>
 
   <div id="map"></div>
+  <pre id="features"></pre>
 
   <script>
     const MAPTILER_KEY = 'ixxHuwQrBFlQ9PcwEp0D'; //this is key from https://cloud.maptiler.com/account/keys/
@@ -67,6 +82,39 @@
           });
         })
         .catch(error => console.error('Error loading GeoJSON:', error));
+
+    });
+    map.on('click', (e) => {
+      const features = map.queryRenderedFeatures(e.point, {
+        layers: ['3d-buildings'] //parameter grabs on 3d buildings, can remove
+      });
+
+      // Limit the number of properties we're displaying for
+      // legibility and performance
+      const displayProperties = [
+        'type',
+        'properties',
+        'id',
+        'layer',
+        'source',
+        'sourceLayer',
+        'state'
+      ];
+
+      const displayFeatures = features.map((feat) => {
+        const displayFeat = {};
+        displayProperties.forEach((prop) => {
+          displayFeat[prop] = feat[prop];
+        });
+        return displayFeat;
+      });
+
+      document.getElementById('features').innerHTML = JSON.stringify(
+              displayFeatures,
+              null,
+              2
+      );
+
     });
   </script>
 


### PR DESCRIPTION
Added ability to click on a building and for now it shows respective Json data of said building.

We can grab the json data of clicked building and feed it into a predictors .sav file. 
Then we can add a better interface, instead of showing json we can show maybe current predictive heating and cooling loads? 